### PR TITLE
Fix phone number to +971 50 647 9919

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@ footer{position:relative;z-index:2;border-top:3px solid var(--red);padding:30px 
     <div class="hero-meta">
       <div>EST. 5+ YRS — GENAI × CLOUD</div>
       <div class="scroll-hint"><div class="wheel"></div>SCROLL TO FIRE THE WEB</div>
-      <div>DUBAI JVC · UAE · +971 50 654 7991 9</div>
+      <div>DUBAI JVC · UAE · +971 50 647 9919</div>
     </div>
   </section>
 
@@ -541,7 +541,7 @@ footer{position:relative;z-index:2;border-top:3px solid var(--red);padding:30px 
     <p class="hero-sub reveal" style="opacity:1;margin:26px auto 0;text-align:center">Email me, call me, or just say hi from anywhere in the multiverse. <b>Your next production GenAI platform starts right here.</b></p>
     <div class="mega-cta reveal">
       <a class="btn btn-primary hoverable magnetic" data-label="SEND IT!" href="mailto:priyansh.9071@gmail.com"><span class="dot"></span> priyansh.9071@gmail.com</a>
-      <a class="btn btn-ghost hoverable magnetic" data-label="RING RING!" href="tel:+9715065479919">📞 +971 50 654 7991 9</a>
+      <a class="btn btn-ghost hoverable magnetic" data-label="RING RING!" href="tel:+971506479919">📞 +971 50 647 9919</a>
     </div>
     <div class="social-row reveal">
       <a class="social hoverable" href="https://github.com/priyansh19" target="_blank" rel="noopener">
@@ -552,7 +552,7 @@ footer{position:relative;z-index:2;border-top:3px solid var(--red);padding:30px 
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.4 2H3.6C2.7 2 2 2.7 2 3.6v16.8c0 .9.7 1.6 1.6 1.6h16.8c.9 0 1.6-.7 1.6-1.6V3.6c0-.9-.7-1.6-1.6-1.6zM8.1 18.7H5.2V9.7h2.9v9zM6.6 8.4a1.7 1.7 0 1 1 0-3.4 1.7 1.7 0 0 1 0 3.4zm12.1 10.3h-2.9v-4.4c0-1 0-2.4-1.5-2.4s-1.7 1.1-1.7 2.3v4.5H9.7V9.7h2.8V11h.1c.4-.7 1.3-1.5 2.8-1.5 3 0 3.5 2 3.5 4.5v4.7z"/></svg>
         LinkedIn
       </a>
-      <a class="social hoverable" href="https://wa.me/9715065479919" target="_blank" rel="noopener">
+      <a class="social hoverable" href="https://wa.me/971506479919" target="_blank" rel="noopener">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 0 0-8.6 15.1L2 22l5-1.3A10 10 0 1 0 12 2zm5.5 14.1c-.2.7-1.3 1.3-1.9 1.4-.5.1-1.1.1-1.8-.1-.4-.1-1-.3-1.7-.6-2.9-1.3-4.8-4.2-5-4.4-.1-.2-1.2-1.6-1.2-3s.8-2.1 1-2.4c.3-.3.6-.4.8-.4h.6c.2 0 .4 0 .7.5.2.6.8 2 .9 2.2.1.2.1.4 0 .6-.1.2-.2.4-.4.6l-.5.6c-.2.2-.3.4-.1.7.2.3.8 1.3 1.8 2.2 1.2 1.1 2.2 1.4 2.6 1.6.3.2.5.1.7-.1l1-1.1c.2-.3.4-.2.7-.1.3.1 1.8.8 2.1 1 .3.2.5.2.6.4.1.1.1.7-.1 1.4z"/></svg>
         WhatsApp
       </a>


### PR DESCRIPTION
## Summary

Corrects the phone number across the site to **+971 50 647 9919** (matching the resume):

- Hero meta strip display
- Contact section tap-to-call button (`tel:+971506479919`)
- WhatsApp link (`wa.me/971506479919`)

Targets `master` since that's the GitHub Pages deploy branch — merge to go live.

https://claude.ai/code/session_013WkysTuQP1DV5PNUNqNHqB

---
_Generated by [Claude Code](https://claude.ai/code/session_013WkysTuQP1DV5PNUNqNHqB)_